### PR TITLE
(IMPORTANT BUG FIX!!!) Fixing the "\b" character bug

### DIFF
--- a/src/main/java/view/SearchView.java
+++ b/src/main/java/view/SearchView.java
@@ -94,7 +94,14 @@ public class SearchView extends JPanel implements ActionListener, PropertyChange
                     public void keyTyped(KeyEvent e) {
                         SearchState currentState = searchViewModel.getState();
                         String text = searchInputField.getText() + e.getKeyChar();
-                        currentState.setSearchCriteria(text);
+                        String accumulator = "";
+                        for (int counter = 0; counter < text.length(); counter++) {
+                            String substring = text.substring(counter, counter + 1);
+                            if (!(substring.equals("\b"))) {
+                                accumulator += accumulator + substring;
+                            }
+                        }
+                        currentState.setSearchCriteria(accumulator);
                         searchViewModel.setState(currentState);
                     }
 


### PR DESCRIPTION
- Look at lines 97-104 in the SearchView in order to fix this bug. Note that this applies to fix backslash characters only, although this algorithm could be applied to other characters such as whitespace characters depending on the use case. This bug fix *should* work for most use cases, although the implementation can vary.